### PR TITLE
Fix subquery parameters and indexing

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -843,11 +843,7 @@ func (b *Builder) InnerJoin(table string, onCondition string) BuilderInterface {
  * @return string
  * @access public
  */
-// Delete deletes rows from a table
-func (b *Builder) Delete() (string, []interface{}, error) {
-	// Reset parameters for new query
-	b.resetParams()
-
+func (b *Builder) deleteSQL() (string, []interface{}, error) {
 	// First validate any collected errors from fluent chaining
 	if err := b.validateAndReturnError(); err != nil {
 		return "", nil, err
@@ -886,6 +882,13 @@ func (b *Builder) Delete() (string, []interface{}, error) {
 		sql = "DELETE FROM " + b.quoteTable(b.sqlTableName) + where + orderBy + limit + offset + ";"
 	}
 	return sql, b.params, nil
+}
+
+// Delete deletes rows from a table
+func (b *Builder) Delete() (string, []interface{}, error) {
+	// Reset parameters for new query
+	b.resetParams()
+	return b.deleteSQL()
 }
 
 // Drop deletes a table or a view
@@ -1110,10 +1113,7 @@ func (b *Builder) TableColumnRename(tableName, oldColumnName, newColumnName stri
  * @return mixed rows as associative array, false on error
  * @access public
  */
-func (b *Builder) Select(columns []string) (string, []interface{}, error) {
-	// Reset parameters for new query
-	b.resetParams()
-
+func (b *Builder) selectSQL(columns []string) (string, []interface{}, error) {
 	// First validate any collected errors from fluent chaining
 	if err := b.validateAndReturnError(); err != nil {
 		return "", nil, err
@@ -1203,6 +1203,12 @@ func (b *Builder) Select(columns []string) (string, []interface{}, error) {
 	return sql, b.params, nil
 }
 
+func (b *Builder) Select(columns []string) (string, []interface{}, error) {
+	// Reset parameters for new query
+	b.resetParams()
+	return b.selectSQL(columns)
+}
+
 /**
  * The <b>update</b> method updates the values of a row in a table.
  * <code>
@@ -1231,10 +1237,7 @@ func (b *Builder) Select(columns []string) (string, []interface{}, error) {
 //	  Insert(map[string]string{"name": "John", "email": "john@example.com"})
 //
 // Returns the SQL statement and parameters for execution.
-func (b *Builder) Insert(columnValuesMap map[string]string) (string, []interface{}, error) {
-	// Reset parameters for new query
-	b.resetParams()
-
+func (b *Builder) insertSQL(columnValuesMap map[string]string) (string, []interface{}, error) {
 	// First validate any collected errors from fluent chaining
 	if err := b.validateAndReturnError(); err != nil {
 		return "", nil, err
@@ -1277,6 +1280,29 @@ func (b *Builder) Insert(columnValuesMap map[string]string) (string, []interface
 	}
 
 	return "INSERT INTO " + b.quoteTable(b.sqlTableName) + " (" + strings.Join(columnNames, ", ") + ") VALUES (" + strings.Join(columnValues, ", ") + ")" + limit + offset + ";", b.params, nil
+}
+
+// Insert inserts a row into a table.
+//
+// NOTE: This method inserts a single record. For bulk inserts, be aware of database parameter limits:
+//   - SQLite: 999 parameters per statement (e.g., 124 records with 8 columns each)
+//   - MySQL: ~65,535 parameters (limited by max_allowed_packet setting)
+//   - PostgreSQL: ~32,767 parameters for prepared statements
+//   - MSSQL: 2,100 parameters
+//
+// For large bulk inserts, split data into batches to avoid "too many SQL variables" errors.
+//
+// Example:
+//
+//	sql, params, err := sb.NewBuilder(sb.DIALECT_SQLITE).
+//	  Table("users").
+//	  Insert(map[string]string{"name": "John", "email": "john@example.com"})
+//
+// Returns the SQL statement and parameters for execution.
+func (b *Builder) Insert(columnValuesMap map[string]string) (string, []interface{}, error) {
+	// Reset parameters for new query
+	b.resetParams()
+	return b.insertSQL(columnValuesMap)
 }
 
 // Truncate removes all data from a table.
@@ -1372,10 +1398,7 @@ func (b *Builder) TruncateWithOptions(opts TruncateOptions) (string, error) {
 //	sql := sb.NewBuilder(sb.DIALECT_MYSQL).Table("users").
 //	  Where(sb.Where{Column: "id", Operator: "=", Value: "1"}).
 //	  Update(map[string]string{"name": "John", "email": "john@example.com"})
-func (b *Builder) Update(columnValues map[string]string) (string, []interface{}, error) {
-	// Reset parameters for new query
-	b.resetParams()
-
+func (b *Builder) updateSQL(columnValues map[string]string) (string, []interface{}, error) {
 	// First validate any collected errors from fluent chaining
 	if err := b.validateAndReturnError(); err != nil {
 		return "", nil, err
@@ -1436,6 +1459,19 @@ func (b *Builder) Update(columnValues map[string]string) (string, []interface{},
 	}
 
 	return "UPDATE " + b.quoteTable(b.sqlTableName) + " SET " + strings.Join(updateSql, ", ") + join + where + groupBy + orderBy + limit + offset + ";", b.params, nil
+}
+
+// Update updates the values of rows in a table.
+//
+// Example:
+//
+//	sql := sb.NewBuilder(sb.DIALECT_MYSQL).Table("users").
+//	  Where(sb.Where{Column: "id", Operator: "=", Value: "1"}).
+//	  Update(map[string]string{"name": "John", "email": "john@example.com"})
+func (b *Builder) Update(columnValues map[string]string) (string, []interface{}, error) {
+	// Reset parameters for new query
+	b.resetParams()
+	return b.updateSQL(columnValues)
 }
 
 // Where adds a WHERE clause to the query.

--- a/builder_test.go
+++ b/builder_test.go
@@ -2603,3 +2603,40 @@ func TestWhereClauseSQLOperators(t *testing.T) {
 		})
 	}
 }
+func TestPostgresSubqueryParameterIndexing(t *testing.T) {
+	b := sb.NewBuilder(sb.DIALECT_POSTGRES)
+
+	subquery := sb.NewBuilder(sb.DIALECT_POSTGRES).
+		Table("orders").
+		Where(&sb.Where{Column: "total", Operator: ">", Value: "1000"})
+
+	b.Table("users").
+		Where(&sb.Where{Column: "status", Operator: "=", Value: "active"})
+
+	_, err := b.InSubquery(subquery)
+	if err != nil {
+		t.Fatalf("Unexpected error in InSubquery: %v", err)
+	}
+
+	sql, params, err := b.Select([]string{"name"})
+
+	if err != nil {
+		t.Fatalf("Unexpected error in Select: %v", err)
+	}
+
+	expectedSQL := `SELECT "name" FROM "users" WHERE "status" = $1 AND "id" IN (SELECT * FROM "orders" WHERE "total" > $2);`
+	if sql != expectedSQL {
+		t.Errorf("Expected SQL:\n%s\nGot:\n%s", expectedSQL, sql)
+	}
+
+	if len(params) != 2 {
+		t.Errorf("Expected 2 parameters, got %d", len(params))
+	} else {
+		if params[0] != "active" {
+			t.Errorf("Expected param 1 to be 'active', got %v", params[0])
+		}
+		if params[1] != "1000" {
+			t.Errorf("Expected param 2 to be '1000', got %v", params[1])
+		}
+	}
+}

--- a/builder_where.go
+++ b/builder_where.go
@@ -232,11 +232,16 @@ func (b *Builder) whereToSqlSubquery(where Where) (string, error) {
 	}
 
 	// Generate subquery SQL without the trailing semicolon
-	// Note: Select now returns (sql, params, error) but we only need the SQL for subqueries
-	subquerySQL, _, err := where.Subquery.Select(columns)
+	// Sync paramIndex to ensure correct parameter placeholder numbering in subqueries
+	where.Subquery.paramIndex = b.paramIndex
+	subquerySQL, subqueryParams, err := where.Subquery.selectSQL(columns)
 	if err != nil {
 		return "", err
 	}
+
+	// Add subquery parameters to the parent builder
+	b.params = append(b.params, subqueryParams...)
+	b.paramIndex += len(subqueryParams)
 	// Remove the trailing semicolon from subquery
 	subquerySQL = strings.TrimSuffix(subquerySQL, ";")
 

--- a/examples/subquery-operations/subquery_test.go
+++ b/examples/subquery-operations/subquery_test.go
@@ -64,8 +64,8 @@ func TestCorrelatedSubquery(t *testing.T) {
 	if sql == "" {
 		t.Fatal("SQL should not be empty")
 	}
-	if len(params) != 1 {
-		t.Fatalf("Expected 1 parameter, got %d", len(params))
+	if len(params) != 2 {
+		t.Fatalf("Expected 2 parameters, got %d", len(params))
 	}
 }
 


### PR DESCRIPTION
This change fixes an issue where parameters from subqueries were being ignored and parameter indexing was incorrect for dialects like PostgreSQL.

Specifically:
- Public methods like `Select`, `Insert`, `Update`, and `Delete` now call internal methods `selectSQL`, etc., after resetting the parameter state.
- `whereToSqlSubquery` now synchronizes the subquery's `paramIndex` with the parent builder before generating SQL and collects the resulting parameters.
- A new test `TestPostgresSubqueryParameterIndexing` verifies that multiple parameters across parent and subqueries are correctly indexed (e.g., $1, $2, $3) in PostgreSQL.
- Updated `examples/subquery-operations/subquery_test.go` to reflect correct parameter counts.

---
*PR created automatically by Jules for task [10693021233940452159](https://jules.google.com/task/10693021233940452159) started by @lesichkovm*